### PR TITLE
fix tpb api for searches with only one page of results

### DIFF
--- a/flood/api.py
+++ b/flood/api.py
@@ -71,11 +71,12 @@ class PirateBayApi(TorrentApi):
         table = soup.find(name='table', id='searchResult')
         pagination = soup.find(id='main-content').find_next_sibling('div')
         num_pages = len(pagination.find_all('a'))
+        if num_pages == 0:  # no pagination links means there is only one page
+            num_pages = 1
 
         torrents = []
-        if num_pages > 0:
-            for row in table.find_all('tr', recursive=False):
-                torrents.append(self._row_to_torrent(row))
+        for row in table.find_all('tr', recursive=False):
+            torrents.append(self._row_to_torrent(row))
 
         return torrents, num_pages
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-beautifulsoup4==4.3.2
-lxml==3.2.4
-requests==2.1.0
+beautifulsoup4==4.5.0
+lxml==3.6.1
+requests==2.10.0

--- a/tests/fixtures/piratebay_response_one_page.html
+++ b/tests/fixtures/piratebay_response_one_page.html
@@ -1,0 +1,544 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>The Pirate Bay - The galaxy's most resilient bittorrent site</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <meta name="google-site-verification" content="bERYeomIC5eBWlPLupPPYPYGA9GvAUKzFHh3WIw24Xs" />
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Search The Pirate Bay" />
+    <link rel="stylesheet" type="text/css" href="//thepiratebay.org/static/css/pirate6.css"/>
+    <link rel="dns-prefetch" href="//syndication.exoclick.com/">
+    <link rel="dns-prefetch" href="//main.exoclick.com/">
+    <link rel="dns-prefetch" href="//static-ssl.exoclick.com/">
+    <link rel="dns-prefetch" href="//ads.exoclick.com/">
+    <link rel="canonical" href="//thepiratebay.org/search/big%20buck%20bunny/0/99/0" />
+    <style type="text/css">
+        .searchBox{
+            margin: 6px;
+            width: 300px;
+            vertical-align: middle;
+            padding: 2px;
+            background-image:url('//thepiratebay.org/static/img/icon-https.gif');
+            background-repeat:no-repeat;
+            background-position: right;
+        }
+        .detLink {
+            font-size: 1.2em;
+            font-weight: 400;
+        }
+        .detDesc {
+            color: #4e5456;
+        }
+        .detDesc a:hover {
+            color: #000099;
+            text-decoration: underline;
+        }
+        .sortby {
+            text-align: left;
+            float: left;
+        }
+        .detName {
+            padding-top: 3px;
+            padding-bottom: 2px;
+        }
+        .viewswitch {
+            font-style: normal;
+            float: right;
+            text-align: right;
+            font-weight: normal;
+        }
+    </style>
+    <meta name="description" content="Search for and download any torrent from the pirate bay using search query big buck bunny. Direct download via magnet link."/>
+    <meta name="keywords" content="big buck bunny direct download torrent magnet tpb piratebay search"/>
+
+</head>
+
+<body>
+    <div id="header">
+
+        <form method="get" id="q" action="/s/">
+            <a href="/" class="img"><img src="//thepiratebay.org/static/img/tpblogo_sm_ny.gif" id="TPBlogo" alt="The Pirate Bay" /></a>
+            <b><a href="/" title="Search Torrents">Search Torrents</a></b>&nbsp;&nbsp;|&nbsp;
+ <a href="/browse" title="Browse Torrents">Browse Torrents</a>&nbsp;&nbsp;|&nbsp;
+ <a href="/recent" title="Recent Torrent">Recent Torrents</a>&nbsp;&nbsp;|&nbsp;
+ <a href="/tv/" title="TV shows">TV shows</a>&nbsp;&nbsp;|&nbsp;
+ <a href="/music" title="Music">Music</a>&nbsp;&nbsp;|&nbsp;
+ <a href="/top" title="Top 100">Top 100</a>
+            <br /><input type="search" class="inputbox" title="Pirate Search" name="q" placeholder="Search here..." value="big buck bunny" /><input value="Pirate Search" type="submit" class="submitbutton" $disabled /><br />            <label for="audio" title="Audio"><input id="audio" name="audio" onclick="javascript:rmAll();" type="checkbox"/>Audio</label>
+            <label for="video" title="Video"><input id="video" name="video" onclick="javascript:rmAll();" type="checkbox"/>Video</label>
+            <label for="apps" title="Applications"><input id="apps" name="apps" onclick="javascript:rmAll();" type="checkbox"/>Applications</label>
+            <label for="games" title="Games"><input id="games" name="games" onclick="javascript:rmAll();" type="checkbox"/>Games</label>
+            <label for="porn" title="Porn"><input id="porn" name="porn" onclick="javascript:rmAll();" type="checkbox"/>Porn</label>
+            <label for="other" title="Other"><input id="other" name="other" onclick="javascript:rmAll();" type="checkbox"/>Other</label>
+
+            <select id="category" name="category" onchange="javascript:setAll();">
+                <option value="0">All</option>
+                <optgroup label="Audio">
+                    <option value="101">Music</option>
+                    <option value="102">Audio books</option>
+                    <option value="103">Sound clips</option>
+                    <option value="104">FLAC</option>
+                    <option value="199">Other</option>
+                </optgroup>
+                <optgroup label="Video">
+                    <option value="201">Movies</option>
+                    <option value="202">Movies DVDR</option>
+                    <option value="203">Music videos</option>
+                    <option value="204">Movie clips</option>
+                    <option value="205">TV shows</option>
+                    <option value="206">Handheld</option>
+                    <option value="207">HD - Movies</option>
+                    <option value="208">HD - TV shows</option>
+                    <option value="209">3D</option>
+                    <option value="299">Other</option>
+                </optgroup>
+                <optgroup label="Applications">
+                    <option value="301">Windows</option>
+                    <option value="302">Mac</option>
+                    <option value="303">UNIX</option>
+                    <option value="304">Handheld</option>
+                    <option value="305">IOS (iPad/iPhone)</option>
+                    <option value="306">Android</option>
+                    <option value="399">Other OS</option>
+                </optgroup>
+                <optgroup label="Games">
+                    <option value="401">PC</option>
+                    <option value="402">Mac</option>
+                    <option value="403">PSx</option>
+                    <option value="404">XBOX360</option>
+                    <option value="405">Wii</option>
+                    <option value="406">Handheld</option>
+                    <option value="407">IOS (iPad/iPhone)</option>
+                    <option value="408">Android</option>
+                    <option value="499">Other</option>
+                </optgroup>
+                <optgroup label="Porn">
+                    <option value="501">Movies</option>
+                    <option value="502">Movies DVDR</option>
+                    <option value="503">Pictures</option>
+                    <option value="504">Games</option>
+                    <option value="505">HD - Movies</option>
+                    <option value="506">Movie clips</option>
+                    <option value="599">Other</option>
+                </optgroup>
+                <optgroup label="Other">
+                    <option value="601">E-books</option>
+                    <option value="602">Comics</option>
+                    <option value="603">Pictures</option>
+                    <option value="604">Covers</option>
+                    <option value="605">Physibles</option>
+                    <option value="699">Other</option>
+                </optgroup>
+            </select>
+
+            <input type="hidden" name="page" value="0" />
+            <input type="hidden" name="orderby" value="99" />
+        </form>
+    </div><!-- // div:header -->
+
+    <h2><span>Search results: big buck bunny</span>&nbsp;Displaying hits from 0 to 22 (approx 22 found)</h2>
+
+<div id="SearchResults"><div id="content">
+			<div id="sky-right">
+				 <iframe src="//thepiratebay.org/static/ads/exo_na/sky2.html" width="160" height="600" frameborder="0" scrolling="no"></iframe>
+			</div>
+	
+		 <iframe src="//thepiratebay.org/static/ads/exo_na/center.html" id="sky-center" width="728" height="90" frameborder="0" scrolling="no"></iframe>
+	<div id="main-content">
+<table id="searchResult">
+	<thead id="tableHead">
+		<tr class="header">
+			<th><a href="/search/big%20buck%20bunny/0/13/0" title="Order by Type">Type</a></th>
+			<th><div class="sortby"><a href="/search/big%20buck%20bunny/0/1/0" title="Order by Name">Name</a> (Order by: <a href="/search/big%20buck%20bunny/0/3/0" title="Order by Uploaded">Uploaded</a>, <a href="/search/big%20buck%20bunny/0/5/0" title="Order by Size">Size</a>, <span style="white-space: nowrap;"><a href="/search/big%20buck%20bunny/0/11/0" title="Order by ULed by">ULed by</a></span>, <a href="/search/big%20buck%20bunny/0/8/0" title="Order by Seeders">SE</a>, <a href="/search/big%20buck%20bunny/0/9/0" title="Order by Leechers">LE</a>)</div><div class="viewswitch"> View: <a href="/switchview.php?view=s">Single</a> / Double&nbsp;</div></th>
+			<th><abbr title="Seeders"><a href="/search/big%20buck%20bunny/0/8/0" title="Order by Seeders">SE</a></abbr></th>
+			<th><abbr title="Leechers"><a href="/search/big%20buck%20bunny/0/9/0" title="Order by Leechers">LE</a></abbr></th>
+		</tr>
+	</thead>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/299" title="More from this category">Other</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/4206613/Big_Buck_Bunny_(Peach)__720p_Stereo_OGG_Theora_version" class="detLink" title="Details for Big Buck Bunny (Peach): 720p Stereo OGG Theora version">Big Buck Bunny (Peach): 720p Stereo OGG Theora version</a>
+</div>
+<a href="magnet:?xt=urn:btih:ee1bb44f0fd3fb1be4cecb32ff9aa2242f7b1497&dn=Big+Buck+Bunny+%28Peach%29%3A+720p+Stereo+OGG+Theora+version&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 2 comments." title="This torrent has 2 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 05-26&nbsp;2008, Size 187.78&nbsp;MiB, ULed by <a class="detDesc" href="/user/daradib/" title="Browse daradib">daradib</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/206" title="More from this category">Handheld</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/4224248/Big_Buck_Bunny.2008.640x360.x264-ozz314.mp4_(iPod_iPhone_Flash)" class="detLink" title="Details for Big_Buck_Bunny.2008.640x360.x264-ozz314.mp4 (iPod/iPhone/Flash)">Big_Buck_Bunny.2008.640x360.x264-ozz314.mp4 (iPod/iPhone/Flash)</a>
+</div>
+<a href="magnet:?xt=urn:btih:0a697e37a195705eda5a15b8337923041ef78e67&dn=Big_Buck_Bunny.2008.640x360.x264-ozz314.mp4+%28iPod%2FiPhone%2FFlash%29&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/11x11p.png" /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 06-06&nbsp;2008, Size 82.17&nbsp;MiB, ULed by <a class="detDesc" href="/user/ozz314/" title="Browse ozz314">ozz314</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">1</td>
+	</tr>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/207" title="More from this category">HD - Movies</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/4224333/Big_Buck_Bunny_1080p_(x264__ac3)" class="detLink" title="Details for Big Buck Bunny 1080p (x264, ac3)">Big Buck Bunny 1080p (x264, ac3)</a>
+</div>
+<a href="magnet:?xt=urn:btih:2e86074b4851b2b964a1d8db9fae2e7f0b763d03&dn=Big+Buck+Bunny+1080p+%28x264%2C+ac3%29&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 8 comments." title="This torrent has 8 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 06-06&nbsp;2008, Size 451.06&nbsp;MiB, ULed by <a class="detDesc" href="/user/saintdev/" title="Browse saintdev">saintdev</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">1</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/299" title="More from this category">Other</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/4227581/Big_Buck_Bunny_480p_(x264__he-aac)" class="detLink" title="Details for Big Buck Bunny 480p (x264, he-aac)">Big Buck Bunny 480p (x264, he-aac)</a>
+</div>
+<a href="magnet:?xt=urn:btih:05d51d7153228e08d94f850e5d2ce0a9e764752e&dn=Big+Buck+Bunny+480p+%28x264%2C+he-aac%29&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 1 comments." title="This torrent has 1 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 06-08&nbsp;2008, Size 123.3&nbsp;MiB, ULed by <a class="detDesc" href="/user/saintdev/" title="Browse saintdev">saintdev</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">1</td>
+	</tr>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/100" title="More from this category">Audio</a><br />
+				(<a href="/browse/101" title="More from this category">Music</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/4294609/Big_Buck_Bunny_soundtracks_-_Stereo_Extended_mp3_(MP3_Surround)" class="detLink" title="Details for Big Buck Bunny soundtracks - Stereo Extended mp3 (MP3 Surround)">Big Buck Bunny soundtracks - Stereo Extended mp3 (MP3 Surround)</a>
+</div>
+<a href="magnet:?xt=urn:btih:c6c0ad46f72e903fa83b68b494f353bef0277a79&dn=Big+Buck+Bunny+soundtracks+-+Stereo+Extended+mp3+%28MP3+Surround%29&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/11x11p.png" /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 07-14&nbsp;2008, Size 17.65&nbsp;MiB, ULed by <a class="detDesc" href="/user/freewareprirate/" title="Browse freewareprirate">freewareprirate</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/201" title="More from this category">Movies</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/4595083/Big.Buck.Bunny.2008.DVDRip.XviD.AC3.SHORT" class="detLink" title="Details for Big.Buck.Bunny.2008.DVDRip.XviD.AC3.SHORT">Big.Buck.Bunny.2008.DVDRip.XviD.AC3.SHORT</a>
+</div>
+<a href="magnet:?xt=urn:btih:d4bf35ebdca1ec5cc4f044483632bddeb0f0563d&dn=Big.Buck.Bunny.2008.DVDRip.XviD.AC3.SHORT&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 5 comments." title="This torrent has 5 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 12-22&nbsp;2008, Size 149.45&nbsp;MiB, ULed by <a class="detDesc" href="/user/circlensess/" title="Browse circlensess">circlensess</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/500" title="More from this category">Porn</a><br />
+				(<a href="/browse/506" title="More from this category">Movie clips</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/4607569/Big.Buck.Bunny.2008.DVDRip.XviD.AC3.Chusty" class="detLink" title="Details for Big.Buck.Bunny.2008.DVDRip.XviD.AC3.Chusty">Big.Buck.Bunny.2008.DVDRip.XviD.AC3.Chusty</a>
+</div>
+<a href="magnet:?xt=urn:btih:6366e0a6d44d49c8fa09c04669375c024e42bf7e&dn=Big.Buck.Bunny.2008.DVDRip.XviD.AC3.Chusty&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 1 comments." title="This torrent has 1 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 12-29&nbsp;2008, Size 149.45&nbsp;MiB, ULed by <a class="detDesc" href="/user/dkhueyjr/" title="Browse dkhueyjr">dkhueyjr</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/207" title="More from this category">HD - Movies</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/4701481/Big_Buck_Bunny_2008_720p_BluRay_x264-DON(No_Rars)" class="detLink" title="Details for Big Buck Bunny 2008 720p BluRay x264-DON(No Rars)">Big Buck Bunny 2008 720p BluRay x264-DON(No Rars)</a>
+</div>
+<a href="magnet:?xt=urn:btih:944a0251967aa4cfa96ca63617f874df03176a0e&dn=Big+Buck+Bunny+2008+720p+BluRay+x264-DON%28No+Rars%29&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 1 comments." title="This torrent has 1 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 02-04&nbsp;2009, Size 369.54&nbsp;MiB, ULed by <a class="detDesc" href="/user/cgaurav007/" title="Browse cgaurav007">cgaurav007</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">1</td>
+	</tr>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/204" title="More from this category">Movie clips</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5316077/Big.Buck.Bunny.BDRip.XviD-MEDiC" class="detLink" title="Details for Big.Buck.Bunny.BDRip.XviD-MEDiC">Big.Buck.Bunny.BDRip.XviD-MEDiC</a>
+</div>
+<a href="magnet:?xt=urn:btih:c39fe3eefbdb62da9c27eb6398ff4a7d2e26e7ab&dn=Big.Buck.Bunny.BDRip.XviD-MEDiC&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 2 comments." title="This torrent has 2 comments." /><a href="/user/.BONE."><img src="//thepiratebay.org/static/img/vip.gif" alt="VIP" title="VIP" style="width:11px;" border='0' /></a>
+			<font class="detDesc">Uploaded 01-28&nbsp;2010, Size 175.06&nbsp;MiB, ULed by <a class="detDesc" href="/user/.BONE./" title="Browse .BONE.">.BONE.</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">1</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/204" title="More from this category">Movie clips</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5317685/Big.Buck.Bunny.BDRip.360p.H264[REQ]" class="detLink" title="Details for Big.Buck.Bunny.BDRip.360p.H264[REQ]">Big.Buck.Bunny.BDRip.360p.H264[REQ]</a>
+</div>
+<a href="magnet:?xt=urn:btih:1658902a7e0ff5838a9dec29dc92f6cd7632ec7b&dn=Big.Buck.Bunny.BDRip.360p.H264%5BREQ%5D&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 1 comments." title="This torrent has 1 comments." /><a href="/user/twentyforty"><img src="//thepiratebay.org/static/img/vip.gif" alt="VIP" title="VIP" style="width:11px;" border='0' /></a>
+			<font class="detDesc">Uploaded 01-29&nbsp;2010, Size 34.67&nbsp;MiB, ULed by <a class="detDesc" href="/user/twentyforty/" title="Browse twentyforty">twentyforty</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/207" title="More from this category">HD - Movies</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5421757/Big.Buck.Bunny.1080p.Surround" class="detLink" title="Details for Big.Buck.Bunny.1080p.Surround">Big.Buck.Bunny.1080p.Surround</a>
+</div>
+<a href="magnet:?xt=urn:btih:9ee38ecc0105ed61b0ef93a875325afe784b6fb5&dn=Big.Buck.Bunny.1080p.Surround&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 1 comments." title="This torrent has 1 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 03-09&nbsp;2010, Size 885.68&nbsp;MiB, ULed by <a class="detDesc" href="/user/SeederZ/" title="Browse SeederZ">SeederZ</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">1</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/201" title="More from this category">Movies</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5426580/big-buck-bunny-PAL.iso" class="detLink" title="Details for big-buck-bunny-PAL.iso">big-buck-bunny-PAL.iso</a>
+</div>
+<a href="magnet:?xt=urn:btih:32a32fcc219e52c771439700647c550dfa3035d5&dn=big-buck-bunny-PAL.iso&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 2 comments." title="This torrent has 2 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 03-11&nbsp;2010, Size 7.51&nbsp;GiB, ULed by <i>Anonymous</i></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/202" title="More from this category">Movies DVDR</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5426602/big-buck-bunny-NTSC.iso" class="detLink" title="Details for big-buck-bunny-NTSC.iso">big-buck-bunny-NTSC.iso</a>
+</div>
+<a href="magnet:?xt=urn:btih:fc84b941dc640be59c90d7ab58819d50edcff906&dn=big-buck-bunny-NTSC.iso&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 2 comments." title="This torrent has 2 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 03-11&nbsp;2010, Size 7.73&nbsp;GiB, ULed by <a class="detDesc" href="/user/DcyMatrix/" title="Browse DcyMatrix">DcyMatrix</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/600" title="More from this category">Other</a><br />
+				(<a href="/browse/699" title="More from this category">Other</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5474368/big_buck_bunny.ogg" class="detLink" title="Details for big_buck_bunny.ogg">big_buck_bunny.ogg</a>
+</div>
+<a href="magnet:?xt=urn:btih:3a117861344ba32bfda791e194934b3535395f96&dn=big_buck_bunny.ogg&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/11x11p.png" /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 03-31&nbsp;2010, Size 159.1&nbsp;MiB, ULed by <a class="detDesc" href="/user/xor666/" title="Browse xor666">xor666</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/299" title="More from this category">Other</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5552367/Big_Buck_Bunny_1080p_surround_FrostWire.com.avi" class="detLink" title="Details for Big_Buck_Bunny_1080p_surround_FrostWire.com.avi">Big_Buck_Bunny_1080p_surround_FrostWire.com.avi</a>
+</div>
+<a href="magnet:?xt=urn:btih:18543e3527002686c3e369ff92bbd2d6a2df8a2c&dn=Big_Buck_Bunny_1080p_surround_FrostWire.com.avi&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/11x11p.png" /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 05-11&nbsp;2010, Size 885.65&nbsp;MiB, ULed by <i>Anonymous</i></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">1</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/207" title="More from this category">HD - Movies</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5579280/Big_Buck_Bunny_(1080p).ogv" class="detLink" title="Details for Big Buck Bunny (1080p).ogv">Big Buck Bunny (1080p).ogv</a>
+</div>
+<a href="magnet:?xt=urn:btih:e541adf64e5d10c0827579447948aefba651e4f4&dn=Big+Buck+Bunny+%281080p%29.ogv&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/11x11p.png" /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 05-21&nbsp;2010, Size 866.82&nbsp;MiB, ULed by <a class="detDesc" href="/user/Gallaecio/" title="Browse Gallaecio">Gallaecio</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/207" title="More from this category">HD - Movies</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5667767/Big_Buck_Bunny_1080p" class="detLink" title="Details for Big Buck Bunny 1080p">Big Buck Bunny 1080p</a>
+</div>
+<a href="magnet:?xt=urn:btih:88b2c9fa7d3493b45130b2907d9ca31fdb8ea7b9&dn=Big+Buck+Bunny+1080p&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 2 comments." title="This torrent has 2 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 07-04&nbsp;2010, Size 888.95&nbsp;MiB, ULed by <a class="detDesc" href="/user/asamson23/" title="Browse asamson23">asamson23</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/600" title="More from this category">Other</a><br />
+				(<a href="/browse/699" title="More from this category">Other</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5696784/(Tkillaahh)_Big_buck_bunny_DVD_-_720P_-_2lions_team" class="detLink" title="Details for (Tkillaahh) Big buck bunny DVD - 720P - 2lions team">(Tkillaahh) Big buck bunny DVD - 720P - 2lions team</a>
+</div>
+<a href="magnet:?xt=urn:btih:0e8d40e2053cc693f0b8d60b845744b61c6af59c&dn=%28Tkillaahh%29+Big+buck+bunny+DVD+-+720P+-+2lions+team&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/11x11p.png" /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 07-17&nbsp;2010, Size 541.09&nbsp;MiB, ULed by <i>Anonymous</i></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/207" title="More from this category">HD - Movies</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5900907/Big_buck_Bunny_[1080p_-_H264_-_Aac_5.1]_[Tntvillage]" class="detLink" title="Details for Big buck Bunny [1080p - H264 - Aac 5.1] [Tntvillage]">Big buck Bunny [1080p - H264 - Aac 5.1] [Tntvillage]</a>
+</div>
+<a href="magnet:?xt=urn:btih:514ff0b2159607c35da3a64fe0a702ff6399c79e&dn=Big+buck+Bunny+%5B1080p+-+H264+-+Aac+5.1%5D+%5BTntvillage%5D&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/11x11p.png" /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 10-21&nbsp;2010, Size 507.41&nbsp;MiB, ULed by <a class="detDesc" href="/user/zabuza89/" title="Browse zabuza89">zabuza89</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">1</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/207" title="More from this category">HD - Movies</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/5975688/Big_Buck_Bunny_(2008)_720p_Bluray_nHD_x264-NhaNc3" class="detLink" title="Details for Big Buck Bunny (2008) 720p Bluray nHD x264-NhaNc3">Big Buck Bunny (2008) 720p Bluray nHD x264-NhaNc3</a>
+</div>
+<a href="magnet:?xt=urn:btih:a9df29de659e590a8ad3cb084407be38ec2ce4f2&dn=Big+Buck+Bunny+%282008%29+720p+Bluray+nHD+x264-NhaNc3&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 1 comments." title="This torrent has 1 comments." /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 11-22&nbsp;2010, Size 209.37&nbsp;MiB, ULed by <a class="detDesc" href="/user/Nishant88/" title="Browse Nishant88">Nishant88</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">1</td>
+	</tr>
+	<tr>
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/207" title="More from this category">HD - Movies</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/6225770/Big_Buck_Bunny_(2008)_BRRip_720p_x264_-MitZep" class="detLink" title="Details for Big Buck Bunny (2008) BRRip 720p x264 -MitZep">Big Buck Bunny (2008) BRRip 720p x264 -MitZep</a>
+</div>
+<a href="magnet:?xt=urn:btih:54dec3e7b1169fad5587d5a9e30fafa92097eab7&dn=Big+Buck+Bunny+%282008%29+BRRip+720p+x264+-MitZep&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/icon_comment.gif" alt="This torrent has 6 comments." title="This torrent has 6 comments." /><a href="/user/MitZep"><img src="//thepiratebay.org/static/img/trusted.png" alt="Trusted" title="Trusted" style="width:11px;" border='0' /></a>
+			<font class="detDesc">Uploaded 03-07&nbsp;2011, Size 74.73&nbsp;MiB, ULed by <a class="detDesc" href="/user/MitZep/" title="Browse MitZep">MitZep</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">1</td>
+	</tr>
+	<tr class="alt">
+		<td class="vertTh">
+			<center>
+				<a href="/browse/200" title="More from this category">Video</a><br />
+				(<a href="/browse/299" title="More from this category">Other</a>)
+			</center>
+		</td>
+		<td>
+<div class="detName">			<a href="/torrent/8971917/big-buck-bunny_trailer.webm" class="detLink" title="Details for big-buck-bunny_trailer.webm">big-buck-bunny_trailer.webm</a>
+</div>
+<a href="magnet:?xt=urn:btih:2544668214576419fd00195acf560469c1befaca&dn=big-buck-bunny_trailer.webm&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fopen.demonii.com%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Fexodus.desync.com%3A6969" title="Download this torrent using magnet"><img src="//thepiratebay.org/static/img/icon-magnet.gif" alt="Magnet link" /></a><img src="//thepiratebay.org/static/img/11x11p.png" /><img src="//thepiratebay.org/static/img/11x11p.png" />
+			<font class="detDesc">Uploaded 09-28&nbsp;2013, Size 2.06&nbsp;MiB, ULed by <a class="detDesc" href="/user/tempacc5/" title="Browse tempacc5">tempacc5</a></font>
+		</td>
+		<td align="right">0</td>
+		<td align="right">0</td>
+	</tr>
+
+</table>
+</div>
+<div align="center"></div>
+			<div class="ads" id="sky-banner">
+				 <iframe src="//thepiratebay.org/static/ads/exo_na/sky1.html" width="120" height="600" frameborder="0" scrolling="no"></iframe>
+			</div>
+	</div></div></div><!-- //div:content -->
+
+	<div id="foot" style="text-align:center;margin-top:1em;">
+
+			 <iframe src="//thepiratebay.org/static/ads/exo_na/bottom.html" width="728" height="90" frameborder="0" scrolling="no"></iframe>
+				<p>
+			<a href="/login" title="Login">Login</a> | 
+			<a href="/register" title="Register">Register</a> | 
+			<a href="/language" title="Select language">Language / Select language</a> |
+			<a href="/about" title="About">About</a> |
+			<a href="/blog" title="Blog">Blog</a>
+			<br />
+			<!--<a href="/contact" title="Contact us">Contact us</a> |-->
+			<a href="/policy" title="Usage policy">Usage policy</a> |
+			<a href="http://uj3wazyk5u4hnvtk.onion" title="TOR">TOR</a> |
+			<a href="/doodles" title="Doodles">Doodles</a> |
+			<a href="http://pirates-forum.org/" title="Forum" target="_blank">Forum</a> 
+			<br />
+		</p>
+
+<br /><a href="http://bitcoin.org" target="_NEW">BitCoin</a>: <b><a href="bitcoin:129TQVAroeehD9fZpzK51NdZGQT4TqifbG">129TQVAroeehD9fZpzK51NdZGQT4TqifbG</a></b><br /><br />
+
+		<div id="fbanners">
+			<a href="/rss" class="rss" title="RSS"><img src="//thepiratebay.org/static/img/rss_small.gif" alt="RSS" /></a>
+		</div><!-- // div:fbanners -->
+	</div><!-- // div:foot -->
+
+</body>
+</html>

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -17,7 +17,7 @@ class TestFlood(unittest.TestCase):
             cls.tpb_response = f.read()
 
         with open(path.join(FIXTURES_DIR, "piratebay_response_one_page.html"), "r") as f:
-            cls.tbp_one_page_response = f.read()
+            cls.tpb_one_page_response = f.read()
 
     def test_add_protocol_when_needed(self):
         api = PirateBayApi("sometpbproxy.com")
@@ -58,7 +58,7 @@ class TestFlood(unittest.TestCase):
     @patch('requests.get')
     def test_tpb_one_page_result(self, mock_get):
         mock_response = Mock()
-        mock_response.text = self.tbp_one_page_response
+        mock_response.text = self.tpb_one_page_response
         mock_get.return_value = mock_response
         api = PirateBayApi()
         torrents, num_pages = api.search("big buck bunny")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,6 +16,9 @@ class TestFlood(unittest.TestCase):
         with open(path.join(FIXTURES_DIR, "piratebay_response.html"), "r") as f:
             cls.tpb_response = f.read()
 
+        with open(path.join(FIXTURES_DIR, "piratebay_response_one_page.html"), "r") as f:
+            cls.tbp_one_page_response = f.read()
+
     def test_add_protocol_when_needed(self):
         api = PirateBayApi("sometpbproxy.com")
         self.assertTrue(api.base_url.startswith("http://"), "Api object adds missing protocol during construction")
@@ -51,6 +54,18 @@ class TestFlood(unittest.TestCase):
         mock_get.assert_called_with('http://thepiratebay.se/search/Dexter/0/7/0')
         torrents, page_num = api.search("Dexter", page=4)
         mock_get.assert_called_with('http://thepiratebay.se/search/Dexter/3/7/0')
+
+    @patch('requests.get')
+    def test_tpb_one_page_result(self, mock_get):
+        mock_response = Mock()
+        mock_response.text = self.tbp_one_page_response
+        mock_get.return_value = mock_response
+        api = PirateBayApi()
+        torrents, num_pages = api.search("big buck bunny")
+        self.assertEqual(len(torrents), 22, "22 torrents are found on this page")
+        self.assertEqual(num_pages, 1, "There is one page with results")
+        expected_first_torrent_name = "Big Buck Bunny (Peach): 720p Stereo OGG Theora version"
+        self.assertEqual(torrents[0].name, expected_first_torrent_name, "First Torrent object in list matches expected Torrent object")
 
     @patch('requests.get')
     def test_kat_search(self, mock_get):


### PR DESCRIPTION
the current implementation returns an empty list if no pagination links are shown. tpb hides those links for searches with only one page of results.
